### PR TITLE
CLI Tools for managing Events and Announcements

### DIFF
--- a/cmd/csuf/cmd/root.go
+++ b/cmd/csuf/cmd/root.go
@@ -1,20 +1,17 @@
 package cmd
 
 import (
-	"fmt"
 	"log"
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/acmcsufoss/api.acmcsuf.com/internal/cli/events"
 )
 
 var rootCmd = &cobra.Command{
 	Use:   "csuf",
 	Short: "A CLI tool to help manage the API of the CSUF ACM website",
-
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("CSUF API TOOL")
-	},
 }
 
 func Execute() {
@@ -30,5 +27,5 @@ func Execute() {
 }
 
 func init() {
-	//rootCmd.AddCommand
+	rootCmd.AddCommand(events.CLIEvents)
 }

--- a/cmd/csuf/cmd/root.go
+++ b/cmd/csuf/cmd/root.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "csuf",
+	Short: "A CLI tool to help manage the API of the CSUF ACM website",
+
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("CSUF API TOOL")
+	},
+}
+
+func Execute() {
+
+	// Logging the error, prefix is date, time, and what file the log is from
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+
+	if err := rootCmd.Execute(); err != nil {
+		log.Println("Error with CLI:", err)
+		os.Exit(1)
+	}
+
+}
+
+func init() {
+	//rootCmd.AddCommand
+}

--- a/cmd/csuf/cmd/root.go
+++ b/cmd/csuf/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/acmcsufoss/api.acmcsuf.com/internal/cli/announcements"
 	"github.com/acmcsufoss/api.acmcsuf.com/internal/cli/events"
 )
 
@@ -28,4 +29,5 @@ func Execute() {
 
 func init() {
 	rootCmd.AddCommand(events.CLIEvents)
+	rootCmd.AddCommand(announcements.CLIAnnouncements)
 }

--- a/cmd/csuf/main.go
+++ b/cmd/csuf/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/acmcsufoss/api.acmcsuf.com/csuf/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/cmd/csuf/main.go
+++ b/cmd/csuf/main.go
@@ -1,7 +1,12 @@
 package main
 
-import "github.com/acmcsufoss/api.acmcsuf.com/csuf/cmd"
+import "github.com/acmcsufoss/api.acmcsuf.com/cmd/csuf/cmd"
 
+// Initalizing cobra here
+// To use the CLI, first, cd into this directory (/api.acmcsuf.com/cmd/csuf)
+// Next, run: go install .
+// Now, if you have not already, export the go bin path: export PATH="$HOME/go/bin:$PATH"
+// Now type csuf in your command line and see what happens!
 func main() {
 	cmd.Execute()
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.23.4
 
 require (
 	github.com/gin-gonic/gin v1.10.0
+	github.com/spf13/cobra v1.9.1
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
 	github.com/swaggo/swag v1.16.4
@@ -41,7 +42,6 @@ require (
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/go-playground/validator/v10 v10.26.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
@@ -40,6 +41,8 @@ require (
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/spf13/cobra v1.9.1 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/bytedance/sonic/loader v0.2.4/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFos
 github.com/cloudwego/base64x v0.1.5 h1:XPciSp1xaq2VCSt6lF0phncD4koWyULpl5bUxbfCyP4=
 github.com/cloudwego/base64x v0.1.5/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -46,6 +47,8 @@ github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd h1:gbpYu9NMq8jhDVbvlG
 github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd/go.mod h1:kf6iHlnVGwgKolg33glAes7Yg/8iWP8ukqeldJSO7jw=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -79,6 +82,11 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/internal/api/handlers/announcement_handler.go
+++ b/internal/api/handlers/announcement_handler.go
@@ -94,7 +94,9 @@ func (h *AnnouncementHandler) CreateAnnouncement(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "Failed to create announcement",
 		})
+		return
 	}
+
 	c.JSON(http.StatusOK, gin.H{
 		"message": "Announcement created successfully",
 		"uuid":    params.Uuid,

--- a/internal/api/handlers/events_handler.go
+++ b/internal/api/handlers/events_handler.go
@@ -3,6 +3,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/acmcsufoss/api.acmcsuf.com/internal/api/services"
@@ -147,6 +148,7 @@ func (h *EventsHandler) UpdateEvent(c *gin.Context) {
 	var params models.UpdateEventParams
 	id := c.Param("id")
 
+	fmt.Println("UPDATE:", id)
 	if err := c.ShouldBindJSON(&params); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "Invalid request body. " + err.Error(),
@@ -155,8 +157,9 @@ func (h *EventsHandler) UpdateEvent(c *gin.Context) {
 	}
 
 	if err := h.eventsService.Update(ctx, id, params); err != nil {
+		error := fmt.Sprint("Failed to update event: ", err, " | ", ctx, " | ", id, " | ", params)
 		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "Failed to update event",
+			"error": error,
 		})
 		return
 	}

--- a/internal/cli/announcements/announcements.go
+++ b/internal/cli/announcements/announcements.go
@@ -1,0 +1,35 @@
+package announcements
+
+import (
+	"database/sql"
+
+	"github.com/spf13/cobra"
+)
+
+var CLIAnnouncements = &cobra.Command{
+	Use:   "announcements",
+	Short: "Manage ACM CSUF's Announcements",
+}
+
+type CreateAnnouncement struct {
+	Uuid             string         `json:"uuid"`
+	Visibility       string         `json:"visibility"`
+	AnnounceAt       int64          `json:"announce_at"`
+	DiscordChannelID sql.NullString `json:"discord_channel_id"`
+	DiscordMessageID sql.NullString `json:"discord_message_id"`
+}
+
+type UpdateAnnouncement struct {
+	Visibility       sql.NullString `json:"visibility"`
+	AnnounceAt       sql.NullInt64  `json:"announce_at"`
+	DiscordChannelID sql.NullString `json:"discord_channel_id"`
+	DiscordMessageID sql.NullString `json:"discord_message_id"`
+	Uuid             string         `json:"uuid"`
+}
+
+func init() {
+	CLIAnnouncements.AddCommand(GetAnnouncement)
+	CLIAnnouncements.AddCommand(PostAnnouncement)
+	CLIAnnouncements.AddCommand(DeleteAnnouncements)
+	CLIAnnouncements.AddCommand(PutAnnouncements)
+}

--- a/internal/cli/announcements/delete.go
+++ b/internal/cli/announcements/delete.go
@@ -1,0 +1,72 @@
+package announcements
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/spf13/cobra"
+)
+
+var DeleteAnnouncements = &cobra.Command{
+	Use:   "delete",
+	Short: "delete an event by its id",
+
+	Run: func(cmd *cobra.Command, args []string) {
+		host, _ := cmd.Flags().GetString("host")
+		port, _ := cmd.Flags().GetString("port")
+		uuid, _ := cmd.Flags().GetString("id")
+
+		deleteAnnouncement(host, port, uuid)
+	},
+}
+
+func init() {
+	DeleteAnnouncements.Flags().String("host", "127.0.0.1", "set a custom host (ex: 127.0.0.1)")
+	DeleteAnnouncements.Flags().String("port", "8080", "set a custom port (ex: 8080)")
+	DeleteAnnouncements.Flags().String("id", "", "delete an announcment by it's id")
+}
+
+func deleteAnnouncement(host string, port string, id string) {
+	if id == "" {
+		fmt.Println("ID is required to delete an announcment! Please use the --id flag")
+		return
+	}
+
+	// ----- Constructing Url -----
+	host = fmt.Sprint(host, ":", port)
+	path := fmt.Sprint("announcements/", id)
+
+	deleteUrl := &url.URL{
+		Scheme: "http",
+		Host:   host,
+		Path:   path,
+	}
+
+	// ----- Delete -----
+	request, err := http.NewRequest(http.MethodDelete, deleteUrl.String(), nil)
+	if err != nil {
+		fmt.Println("error with delete request:", err)
+		return
+	}
+
+	client := http.Client{}
+
+	response, err := client.Do(request)
+	if err != nil {
+		fmt.Println("error with delete response:", err)
+		return
+	}
+	defer response.Body.Close()
+
+	fmt.Println("Request status:", response.Status)
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		fmt.Println("error with reading body:", err)
+		return
+	}
+
+	fmt.Println(string(body))
+}

--- a/internal/cli/announcements/delete.go
+++ b/internal/cli/announcements/delete.go
@@ -61,6 +61,12 @@ func deleteAnnouncement(host string, port string, id string) {
 		fmt.Println("error with delete response:", err)
 		return
 	}
+
+	if response == nil {
+		fmt.Println("no response recieved")
+		return
+	}
+
 	defer response.Body.Close()
 
 	// ----- Read Response Information -----

--- a/internal/cli/announcements/delete.go
+++ b/internal/cli/announcements/delete.go
@@ -23,9 +23,12 @@ var DeleteAnnouncements = &cobra.Command{
 }
 
 func init() {
-	DeleteAnnouncements.Flags().String("host", "127.0.0.1", "set a custom host (ex: 127.0.0.1)")
-	DeleteAnnouncements.Flags().String("port", "8080", "set a custom port (ex: 8080)")
+
+	// Url flags
+	DeleteAnnouncements.Flags().String("host", "127.0.0.1", "set a custom host (Defaults to: 127.0.0.1)")
+	DeleteAnnouncements.Flags().String("port", "8080", "set a custom port (Defaults to: 8080)")
 	DeleteAnnouncements.Flags().String("id", "", "delete an announcment by it's id")
+
 }
 
 func deleteAnnouncement(host string, port string, id string) {
@@ -60,6 +63,7 @@ func deleteAnnouncement(host string, port string, id string) {
 	}
 	defer response.Body.Close()
 
+	// ----- Read Response Information -----
 	fmt.Println("Request status:", response.Status)
 
 	body, err := io.ReadAll(response.Body)

--- a/internal/cli/announcements/get.go
+++ b/internal/cli/announcements/get.go
@@ -23,9 +23,12 @@ var GetAnnouncement = &cobra.Command{
 }
 
 func init() {
-	GetAnnouncement.Flags().String("host", "127.0.0.1", "Set a custom host (ex: 127.0.0.1)")
-	GetAnnouncement.Flags().String("port", "8080", "Set a custom port (ex: 8080)")
+
+	// Url flags
+	GetAnnouncement.Flags().String("host", "127.0.0.1", "Set a custom host (Defaults to: 127.0.0.1)")
+	GetAnnouncement.Flags().String("port", "8080", "Set a custom port (Defaults to: 8080)")
 	GetAnnouncement.Flags().String("id", "", "Get a specific event by it's id")
+
 }
 
 func getAnnouncement(host string, port string, uuid string) {

--- a/internal/cli/announcements/get.go
+++ b/internal/cli/announcements/get.go
@@ -46,16 +46,22 @@ func getAnnouncement(host string, port string, uuid string) {
 	}
 
 	// ----- Requesting Get -----
-	request, err := http.Get(getUrl.String())
+	response, err := http.Get(getUrl.String())
 	if err != nil {
 		fmt.Println("error with request:", err)
 		return
 	}
-	defer request.Body.Close()
 
-	fmt.Println("Response status:", request.Status)
+	if response == nil {
+		fmt.Println("no response recieved")
+		return
+	}
 
-	body, err := io.ReadAll(request.Body)
+	defer response.Body.Close()
+
+	fmt.Println("Response status:", response.Status)
+
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		fmt.Println("error reading body:", err)
 		return

--- a/internal/cli/announcements/get.go
+++ b/internal/cli/announcements/get.go
@@ -1,0 +1,63 @@
+package announcements
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/spf13/cobra"
+)
+
+var GetAnnouncement = &cobra.Command{
+	Use:   "get",
+	Short: "Get an announcement",
+
+	Run: func(cmd *cobra.Command, args []string) {
+		host, _ := cmd.Flags().GetString("host")
+		port, _ := cmd.Flags().GetString("port")
+		uuid, _ := cmd.Flags().GetString("id")
+
+		getAnnouncement(host, port, uuid)
+	},
+}
+
+func init() {
+	GetAnnouncement.Flags().String("host", "127.0.0.1", "Set a custom host (ex: 127.0.0.1)")
+	GetAnnouncement.Flags().String("port", "8080", "Set a custom port (ex: 8080)")
+	GetAnnouncement.Flags().String("id", "", "Get a specific event by it's id")
+}
+
+func getAnnouncement(host string, port string, uuid string) {
+	// ----- Constructing the url -----
+	host = fmt.Sprint(host, ":", port)
+	path := "announcements"
+	if uuid != "" {
+		path = fmt.Sprint(path, "/", uuid)
+	}
+
+	getUrl := &url.URL{
+		Scheme: "http",
+		Host:   host,
+		Path:   path,
+	}
+
+	// ----- Requesting Get -----
+	request, err := http.Get(getUrl.String())
+	if err != nil {
+		fmt.Println("error with request:", err)
+		return
+	}
+	defer request.Body.Close()
+
+	fmt.Println("Response status:", request.Status)
+
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		fmt.Println("error reading body:", err)
+		return
+	}
+
+	fmt.Println(string(body))
+
+}

--- a/internal/cli/announcements/post.go
+++ b/internal/cli/announcements/post.go
@@ -1,0 +1,180 @@
+package announcements
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"fmt"
+
+	"github.com/acmcsufoss/api.acmcsuf.com/utils/convert"
+	"github.com/acmcsufoss/api.acmcsuf.com/utils/dbtypes"
+	"github.com/spf13/cobra"
+)
+
+var PostAnnouncement = &cobra.Command{
+	Use:   "post",
+	Short: "post a new announcment",
+
+	Run: func(cmd *cobra.Command, args []string) {
+		payload := CreateAnnouncement{}
+
+		host, _ := cmd.Flags().GetString("host")
+		port, _ := cmd.Flags().GetString("port")
+		payload.Uuid, _ = cmd.Flags().GetString("id")
+		payload.Visibility, _ = cmd.Flags().GetString("visibility")
+		payload.AnnounceAt, _ = cmd.Flags().GetInt64("announceat")
+		channelIdString, _ := cmd.Flags().GetString("channelid")
+		messageIdString, _ := cmd.Flags().GetString("messageid")
+
+		payload.DiscordChannelID = dbtypes.StringtoNullString(channelIdString)
+		payload.DiscordMessageID = dbtypes.StringtoNullString(messageIdString)
+
+		postAnnouncement(host, port, &payload)
+	},
+}
+
+func init() {
+	PostAnnouncement.Flags().String("host", "127.0.0.1", "Set a custom host (ex: 127.0.0.1)")
+	PostAnnouncement.Flags().String("port", "8080", "Set a custom port (ex: 8080)")
+	PostAnnouncement.Flags().String("id", "", "Set this annoucement's uuid")
+	PostAnnouncement.Flags().StringP("visibility", "v", "", "Set this announcement's visibility")
+	PostAnnouncement.Flags().StringP("announceat", "a", "", "Set this annoucement's announce at (Note: in unix time)")
+	PostAnnouncement.Flags().StringP("channelid", "c", "", "Set this annoucement's channel id")
+	PostAnnouncement.Flags().StringP("messageid", "m", "", "Set this annoucement's message id")
+}
+
+func postAnnouncement(host string, port string, payload *CreateAnnouncement) {
+
+	scanner := bufio.NewScanner(os.Stdin)
+
+	// ----- Uuid -----
+	if payload.Uuid == "" {
+		fmt.Println("Please enter the announcement's uuid:")
+		scanner.Scan()
+		if err := scanner.Err(); err != nil {
+			fmt.Println("error with reading uuid:", err)
+			return
+		}
+
+		uuidBuffer := scanner.Bytes()
+		payload.Uuid = string(uuidBuffer)
+	}
+
+	// ----- Visibility -----
+	if payload.Visibility == "" {
+		fmt.Println("Please enter this annoucement's visibility:")
+		scanner.Scan()
+		if err := scanner.Err(); err != nil {
+			fmt.Println("error with reading visiblity:", err)
+			return
+		}
+
+		visibilityBuffer := scanner.Bytes()
+		payload.Visibility = string(visibilityBuffer)
+	}
+
+	// ----- Announce at -----
+	// As of now this takes unix time directly
+	// I though this would be easier to pull from discord
+	// However, I am unsure, maybe I will do something similar
+	// to the time input in events
+	if payload.AnnounceAt == 0 {
+		fmt.Println("Please enter this annoucement's announce at:")
+		scanner.Scan()
+		if err := scanner.Err(); err != nil {
+			fmt.Println("error reading anounce at:", err)
+			return
+		}
+
+		announceatBuffer := scanner.Bytes()
+
+		// Because := doesnt want to work :l (since payload.AnnounceAt is not new)
+		var err error
+		payload.AnnounceAt, err = convert.ByteSlicetoInt64(announceatBuffer)
+		if err != nil {
+			fmt.Println("error converting byte slice to int64:", err)
+			return
+		}
+	}
+
+	// ----- Discord Channel id -----
+	if !payload.DiscordChannelID.Valid {
+		fmt.Println("Please enter this annoucement's discord channel id:")
+		scanner.Scan()
+		if err := scanner.Err(); err != nil {
+			fmt.Println("error reading  discord channel id:", err)
+			return
+		}
+
+		channelIdBuffer := scanner.Bytes()
+		payload.DiscordChannelID = dbtypes.StringtoNullString(string(channelIdBuffer))
+	}
+
+	// ----- Discord Message id -----
+	if !payload.DiscordMessageID.Valid {
+		fmt.Println("Please enter this annoucement's message id:")
+		scanner.Scan()
+		if err := scanner.Err(); err != nil {
+			fmt.Println("error reading message id:", err)
+			return
+		}
+		messageIdBuffer := scanner.Bytes()
+		payload.DiscordMessageID = dbtypes.StringtoNullString(string(messageIdBuffer))
+	}
+
+	// ----- Confirmation -----
+	fmt.Println("Is your event data correct? If not, type n or no. \n", *payload)
+	scanner.Scan()
+	if err := scanner.Err(); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	confirmationBuffer := scanner.Bytes()
+	confirmationString := strings.ToUpper(string(confirmationBuffer))
+
+	if confirmationString == "NO" || confirmationString == "N" {
+		return
+	}
+
+	// ----- Marshalling to json -----
+	jsonPayload, err := json.Marshal(*payload)
+	if err != nil {
+		fmt.Println("error formating payload to json:", err)
+		return
+	}
+
+	// ----- Constructing the url -----
+	host = fmt.Sprint(host, ":", port)
+	path := "announcements"
+
+	postURL := &url.URL{
+		Scheme: "http",
+		Host:   host,
+		Path:   path,
+	}
+
+	fmt.Println(postURL.String())
+	// ----- Post -----
+	response, err := http.Post(postURL.String(), "application/json", strings.NewReader(string(jsonPayload)))
+	if err != nil {
+		fmt.Println("error with post:", err)
+		return
+	}
+	defer response.Body.Close()
+
+	fmt.Println("Response status:", response.Status)
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		fmt.Println("error reading body:", err)
+		return
+	}
+
+	fmt.Println(string(body))
+}

--- a/internal/cli/announcements/post.go
+++ b/internal/cli/announcements/post.go
@@ -166,6 +166,11 @@ func postAnnouncement(host string, port string, payload *CreateAnnouncement) {
 		fmt.Println("error with post:", err)
 		return
 	}
+
+	if response == nil {
+		fmt.Println("no response recieved")
+		return
+	}
 	defer response.Body.Close()
 
 	fmt.Println("Response status:", response.Status)

--- a/internal/cli/announcements/put.go
+++ b/internal/cli/announcements/put.go
@@ -1,0 +1,249 @@
+package announcements
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/acmcsufoss/api.acmcsuf.com/utils/convert"
+	"github.com/acmcsufoss/api.acmcsuf.com/utils/dbtypes"
+	"github.com/spf13/cobra"
+)
+
+var PutAnnouncements = &cobra.Command{
+	Use:   "put [--host <host>] [--port <port>] --id <uuid>",
+	Short: "update an existing announcement by it's id",
+
+	Run: func(cmd *cobra.Command, args []string) {
+		payload := UpdateAnnouncement{}
+
+		host, _ := cmd.Flags().GetString("host")
+		port, _ := cmd.Flags().GetString("port")
+		payload.Uuid, _ = cmd.Flags().GetString("id")
+		visibilityString, _ := cmd.Flags().GetString("visibility")
+		announceAtInt64, _ := cmd.Flags().GetInt64("announceat")
+		channelIdString, _ := cmd.Flags().GetString("channelid")
+		messageIdString, _ := cmd.Flags().GetString("messageid")
+
+		payload.Visibility = dbtypes.StringtoNullString(visibilityString)
+		payload.AnnounceAt = dbtypes.Int64toNullInt64(announceAtInt64)
+		payload.DiscordChannelID = dbtypes.StringtoNullString(channelIdString)
+		payload.DiscordMessageID = dbtypes.StringtoNullString(messageIdString)
+
+		putAnnouncements(host, port, &payload)
+	},
+}
+
+func init() {
+
+	PutAnnouncements.Flags().String("host", "127.0.0.1", "Set a custom (ex: 127.0.0.1)")
+	PutAnnouncements.Flags().String("port", "8080", "Set a custom (ex: 8080)")
+	PutAnnouncements.Flags().String("id", "", "Get an announcement by it's id")
+	PutAnnouncements.Flags().Int64P("announceat", "a", 0, "Change this announcement's announce at")
+	PutAnnouncements.Flags().StringP("visibility", "v", "", "Change this announcement's visibility")
+	PutAnnouncements.Flags().StringP("channelid", "c", "", "Change this announcement's discord channel id")
+	PutAnnouncements.Flags().StringP("messageid", "m", "", "Change this announcement's discord message id")
+
+}
+
+func putAnnouncements(host string, port string, payload *UpdateAnnouncement) {
+	if payload.Uuid == "" {
+		fmt.Println("Announcement id required for put! Please use the --id flag")
+	}
+
+	// ----- Retrieving old Announcement -----
+	// ----- Constructing Url -----
+	host = fmt.Sprint(host, ":", port)
+	path := fmt.Sprint("announcements/", payload.Uuid)
+
+	oldPayloadUrl := &url.URL{
+		Scheme: "http",
+		Host:   host,
+		Path:   path,
+	}
+
+	// ----- Get the Current Announcement -----
+	request, err := http.Get(oldPayloadUrl.String())
+	if err != nil {
+		fmt.Printf("Error retrieveing %s: %s", payload.Uuid, err)
+		return
+	}
+	defer request.Body.Close()
+
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		fmt.Println("Error reading response body:", err)
+		return
+	}
+
+	var oldPayload CreateAnnouncement
+	json.Unmarshal(body, &oldPayload)
+
+	// ----- Prompt User for New Values -----
+	scanner := bufio.NewScanner(os.Stdin)
+
+	// ----- Uuid -----
+	if payload.Uuid == "" {
+		changeUuid, err := changePrompt("visibility", oldPayload.Visibility, scanner)
+		if err != nil {
+			fmt.Println("error with changing visibility:", err)
+			return
+		}
+		if changeUuid != nil {
+			payload.Uuid = string(changeUuid)
+		} else {
+			payload.Uuid = oldPayload.Uuid
+		}
+	}
+
+	// ----- Visibility -----
+	if payload.Visibility.String == "" {
+		changeVisibility, err := changePrompt("visibility", oldPayload.Visibility, scanner)
+		if err != nil {
+			fmt.Println("error with changing visibility:", err)
+			return
+		}
+		if changeVisibility != nil {
+			payload.Visibility = dbtypes.StringtoNullString(string(changeVisibility))
+		} else {
+			payload.Visibility = dbtypes.StringtoNullString(oldPayload.Visibility)
+		}
+	}
+
+	// ----- Announce At ------
+	if payload.AnnounceAt.Int64 == 0 {
+		// Im sorry
+		oldAnnounceAt := strconv.FormatInt(oldPayload.AnnounceAt, 10)
+		if err != nil {
+			fmt.Println("error with old payload announce at:", err)
+			return
+		}
+
+		changeAnnounceAt, err := changePrompt("announce at", oldAnnounceAt, scanner)
+		if err != nil {
+			fmt.Println("error with changing announce at:", err)
+			return
+		}
+		if changeAnnounceAt != nil {
+			announceAtInt64, err := convert.ByteSlicetoInt64(changeAnnounceAt)
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			payload.AnnounceAt = dbtypes.Int64toNullInt64(announceAtInt64)
+		} else {
+			payload.AnnounceAt = dbtypes.Int64toNullInt64(oldPayload.AnnounceAt)
+		}
+	}
+
+	// ----- Discord Channel ID -----
+	if payload.DiscordChannelID.String == "" {
+		changeDiscordChannelID, err := changePrompt("discord channel id", oldPayload.DiscordChannelID.String, scanner)
+		if err != nil {
+			fmt.Println("error with changing :", err)
+			return
+		}
+		if changeDiscordChannelID != nil {
+			payload.DiscordChannelID = dbtypes.StringtoNullString(string(changeDiscordChannelID))
+		} else {
+			payload.DiscordChannelID = oldPayload.DiscordChannelID
+		}
+	}
+
+	// ----- Discord Message ID -----
+	if payload.DiscordMessageID.String == "" {
+		changeDiscordMessageID, err := changePrompt("discord message id", oldPayload.DiscordMessageID.String, scanner)
+		if err != nil {
+			fmt.Println("error with changing :", err)
+			return
+		}
+		if changeDiscordMessageID != nil {
+			payload.DiscordMessageID = dbtypes.StringtoNullString(string(changeDiscordMessageID))
+		} else {
+			payload.DiscordMessageID = oldPayload.DiscordMessageID
+		}
+	}
+
+	// ----- Marshal Payload to Json -----
+	jsonPayload, err := json.Marshal(*payload)
+	if err != nil {
+		fmt.Println("Error marshaling data:", err)
+		return
+	}
+
+	// ----- Put Payload -----
+	client := &http.Client{}
+
+	putRequest, err := http.NewRequest(http.MethodPut, oldPayloadUrl.String(), bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		fmt.Println("Problem with PUT:", err)
+		return
+	}
+
+	putResponse, err := client.Do(putRequest)
+	if err != nil {
+		fmt.Println("Error with response:", err)
+		return
+	}
+	defer putResponse.Body.Close()
+
+	body, err = io.ReadAll(putResponse.Body)
+	if err != nil {
+		fmt.Println("Error with body:", err)
+		return
+	}
+
+	fmt.Println(string(body))
+
+}
+
+// ============================================= Helper functions =============================================
+
+// Returns a byte slice, if the byte slice is nil, no change will be made. Otherwise, a change will be made
+func changePrompt(dataToBeChanged string, currentData string, scanner *bufio.Scanner) ([]byte, error) {
+	fmt.Printf("Would you like to change this announcements's \x1b[1m%s\x1b[0m?[y/n]\nCurrent announcement's %s: \x1b[93m%s\x1b[0m\n", dataToBeChanged, dataToBeChanged, currentData)
+	scanner.Scan()
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading input: %s", err)
+	}
+	userInput := scanner.Bytes()
+
+	changeData, err := yesOrNo(userInput, scanner)
+	if err != nil {
+		return nil, err
+	}
+	if changeData {
+		fmt.Printf("Please enter a new \x1b[1m%s\x1b[0m for the announcement:\n", dataToBeChanged)
+		scanner.Scan()
+		if err := scanner.Err(); err != nil {
+			return nil, fmt.Errorf("error reading new %s: %s", dataToBeChanged, err)
+		}
+		return scanner.Bytes(), nil
+	} else {
+		return nil, nil
+	}
+}
+
+func yesOrNo(userInput []byte, scanner *bufio.Scanner) (bool, error) {
+	userInputString := strings.ToUpper(string(userInput))
+
+	if userInputString == "YES" || userInputString == "Y" || userInputString == "TRUE" {
+		return true, nil
+	} else if userInputString == "NO" || userInputString == "N" || userInputString == "FALSE" {
+		return false, nil
+	} else {
+		fmt.Println("Invalid input, please try again.")
+		scanner.Scan()
+		if err := scanner.Err(); err != nil {
+			return false, fmt.Errorf("error scanning new input: %s", err)
+		}
+		return yesOrNo(scanner.Bytes(), scanner)
+	}
+}

--- a/internal/cli/announcements/put.go
+++ b/internal/cli/announcements/put.go
@@ -77,14 +77,20 @@ func putAnnouncements(host string, port string, id string, payload *UpdateAnnoun
 	}
 
 	// ----- Get the Announcement We Want to Update -----
-	request, err := http.Get(oldPayloadUrl.String())
+	response, err := http.Get(oldPayloadUrl.String())
 	if err != nil {
 		fmt.Printf("Error retrieveing %s: %s", payload.Uuid, err)
 		return
 	}
-	defer request.Body.Close()
 
-	body, err := io.ReadAll(request.Body)
+	if response == nil {
+		fmt.Println("no response recieved")
+		return
+	}
+
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		fmt.Println("Error reading response body:", err)
 		return
@@ -196,6 +202,12 @@ func putAnnouncements(host string, port string, id string, payload *UpdateAnnoun
 		fmt.Println("Error with response:", err)
 		return
 	}
+
+	if putResponse == nil {
+		fmt.Println("no response recieved")
+		return
+	}
+
 	defer putResponse.Body.Close()
 
 	// ----- Reading Response Status -----

--- a/internal/cli/announcements/put.go
+++ b/internal/cli/announcements/put.go
@@ -97,10 +97,12 @@ func putAnnouncements(host string, port string, id string, payload *UpdateAnnoun
 	scanner := bufio.NewScanner(os.Stdin)
 
 	// ----- Uuid -----
+	// Known issue: Despite the response going through and output saying uuid has been updated
+	// it does not actually update
 	if payload.Uuid == "" {
-		changeUuid, err := changePrompt("visibility", oldPayload.Visibility, scanner)
+		changeUuid, err := changePrompt("uuid", oldPayload.Uuid, scanner)
 		if err != nil {
-			fmt.Println("error with changing visibility:", err)
+			fmt.Println("error with changing uuid:", err)
 			return
 		}
 		if changeUuid != nil {

--- a/internal/cli/events/delete.go
+++ b/internal/cli/events/delete.go
@@ -61,6 +61,12 @@ func deleteEvent(id string, host string, port string) {
 		fmt.Println("Error with delete response:", err)
 		return
 	}
+
+	if response == nil {
+		fmt.Println("no response recieved")
+		return
+	}
+
 	defer response.Body.Close()
 
 	// ----- Read Response Info -----

--- a/internal/cli/events/delete.go
+++ b/internal/cli/events/delete.go
@@ -1,0 +1,74 @@
+package events
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/spf13/cobra"
+)
+
+var DeleteEvent = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete an event with its id",
+
+	Run: func(cmd *cobra.Command, args []string) {
+		id, err := cmd.Flags().GetString("id")
+		if err != nil {
+			fmt.Println("Event ID is required to delete!")
+			return
+		}
+		host, _ := cmd.Flags().GetString("host")
+		port, _ := cmd.Flags().GetString("port")
+
+		deleteEvent(id, host, port)
+	},
+}
+
+func init() {
+	DeleteEvent.Flags().String("id", "", "Delete the identified event")
+	DeleteEvent.Flags().String("host", "127.0.0.1", "Set a custom host (ex: 127.0.0.1)")
+	DeleteEvent.Flags().String("port", "8080", "Set a custom port (ex: 8080)")
+}
+
+func deleteEvent(id string, host string, port string) {
+	if id == "" {
+		fmt.Println("Event ID is required to delete!")
+		return
+	}
+
+	host = fmt.Sprint(host, ":", port)
+	path := fmt.Sprint("events/", id)
+
+	deleteURL := &url.URL{
+		Scheme: "http",
+		Host:   host,
+		Path:   path,
+	}
+
+	//fmt.Println(deleteURL.String())
+
+	client := &http.Client{}
+
+	request, err := http.NewRequest(http.MethodDelete, deleteURL.String(), nil)
+	if err != nil {
+		fmt.Println("Error making delete request:", err)
+		return
+	}
+
+	response, err := client.Do(request)
+	if err != nil {
+		fmt.Println("Error with delete response:", err)
+		return
+	}
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		fmt.Println("Error reading delete response body:,", err)
+		return
+	}
+
+	fmt.Println(string(body))
+}

--- a/internal/cli/events/delete.go
+++ b/internal/cli/events/delete.go
@@ -14,11 +14,7 @@ var DeleteEvent = &cobra.Command{
 	Short: "Delete an event with its id",
 
 	Run: func(cmd *cobra.Command, args []string) {
-		id, err := cmd.Flags().GetString("id")
-		if err != nil {
-			fmt.Println("Event ID is required to delete!")
-			return
-		}
+		id, _ := cmd.Flags().GetString("id")
 		host, _ := cmd.Flags().GetString("host")
 		port, _ := cmd.Flags().GetString("port")
 
@@ -27,12 +23,16 @@ var DeleteEvent = &cobra.Command{
 }
 
 func init() {
+
+	// Url flags
 	DeleteEvent.Flags().String("id", "", "Delete the identified event")
 	DeleteEvent.Flags().String("host", "127.0.0.1", "Set a custom host (ex: 127.0.0.1)")
 	DeleteEvent.Flags().String("port", "8080", "Set a custom port (ex: 8080)")
+
 }
 
 func deleteEvent(id string, host string, port string) {
+	// ----- Check if Event Id was Given -----
 	if id == "" {
 		fmt.Println("Event ID is required to delete!")
 		return
@@ -47,10 +47,9 @@ func deleteEvent(id string, host string, port string) {
 		Path:   path,
 	}
 
-	//fmt.Println(deleteURL.String())
-
 	client := &http.Client{}
 
+	// ----- Delete Request -----
 	request, err := http.NewRequest(http.MethodDelete, deleteURL.String(), nil)
 	if err != nil {
 		fmt.Println("Error making delete request:", err)
@@ -63,6 +62,9 @@ func deleteEvent(id string, host string, port string) {
 		return
 	}
 	defer response.Body.Close()
+
+	// ----- Read Response Info -----
+	fmt.Println("Response status:", response.Status)
 
 	body, err := io.ReadAll(response.Body)
 	if err != nil {

--- a/internal/cli/events/events.go
+++ b/internal/cli/events/events.go
@@ -1,0 +1,38 @@
+package events
+
+import (
+	"database/sql"
+
+	"github.com/spf13/cobra"
+)
+
+var CLIEvents = &cobra.Command{
+	Use:   "events [HTTP HEADER]",
+	Short: "A command to manage events.",
+}
+
+type Event struct {
+	Uuid     string `json:"uuid"`
+	Location string `json:"location"`
+	StartAt  int64  `json:"start_at"`
+	EndAt    int64  `json:"end_at"`
+	IsAllDay bool   `json:"is_all_day"`
+	Host     string `json:"host"`
+}
+
+// Why this? Beacuse PUT uses a different function "UpdateEventParams", instead of "CreateEventParams"
+type UpdateEvent struct {
+	Uuid     string         `json:"uuid"`
+	Location sql.NullString `json:"location"`
+	StartAt  sql.NullInt64  `json:"start_at"`
+	EndAt    sql.NullInt64  `json:"end_at"`
+	IsAllDay sql.NullBool   `json:"is_all_day"`
+	Host     sql.NullString `json:"host"`
+}
+
+func init() {
+	CLIEvents.AddCommand(PostEvent)
+	CLIEvents.AddCommand(GetEvent)
+	//CLIEvents.AddCommand(PutEvents)
+	CLIEvents.AddCommand(DeleteEvent)
+}

--- a/internal/cli/events/events.go
+++ b/internal/cli/events/events.go
@@ -1,6 +1,8 @@
 package events
 
 import (
+	"database/sql"
+
 	"github.com/spf13/cobra"
 )
 
@@ -9,7 +11,7 @@ var CLIEvents = &cobra.Command{
 	Short: "A command to manage events.",
 }
 
-type Event struct {
+type CreateEvent struct {
 	Uuid     string `json:"uuid"`
 	Location string `json:"location"`
 	StartAt  int64  `json:"start_at"`
@@ -18,23 +20,13 @@ type Event struct {
 	Host     string `json:"host"`
 }
 
-// Why this? Beacuse PUT uses a different function "UpdateEventParams", instead of "CreateEventParams"
-/*type PutEvent struct {
+type UpdateEvent struct {
 	Uuid     string         `json:"uuid"`
 	Location sql.NullString `json:"location"`
 	StartAt  sql.NullInt64  `json:"start_at"`
 	EndAt    sql.NullInt64  `json:"end_at"`
 	IsAllDay sql.NullBool   `json:"is_all_day"`
 	Host     sql.NullString `json:"host"`
-}*/
-
-type PutEvent struct {
-	Uuid     *string `json:"uuid"`
-	Location *string `json:"location"`
-	StartAt  *int64  `json:"start_at"`
-	EndAt    *int64  `json:"end_at"`
-	IsAllDay *bool   `json:"is_all_day"`
-	Host     *string `json:"host"`
 }
 
 func init() {

--- a/internal/cli/events/events.go
+++ b/internal/cli/events/events.go
@@ -1,8 +1,6 @@
 package events
 
 import (
-	"database/sql"
-
 	"github.com/spf13/cobra"
 )
 
@@ -21,18 +19,27 @@ type Event struct {
 }
 
 // Why this? Beacuse PUT uses a different function "UpdateEventParams", instead of "CreateEventParams"
-type UpdateEvent struct {
+/*type PutEvent struct {
 	Uuid     string         `json:"uuid"`
 	Location sql.NullString `json:"location"`
 	StartAt  sql.NullInt64  `json:"start_at"`
 	EndAt    sql.NullInt64  `json:"end_at"`
 	IsAllDay sql.NullBool   `json:"is_all_day"`
 	Host     sql.NullString `json:"host"`
+}*/
+
+type PutEvent struct {
+	Uuid     *string `json:"uuid"`
+	Location *string `json:"location"`
+	StartAt  *int64  `json:"start_at"`
+	EndAt    *int64  `json:"end_at"`
+	IsAllDay *bool   `json:"is_all_day"`
+	Host     *string `json:"host"`
 }
 
 func init() {
 	CLIEvents.AddCommand(PostEvent)
 	CLIEvents.AddCommand(GetEvent)
-	//CLIEvents.AddCommand(PutEvents)
+	CLIEvents.AddCommand(PutEvents)
 	CLIEvents.AddCommand(DeleteEvent)
 }

--- a/internal/cli/events/get.go
+++ b/internal/cli/events/get.go
@@ -1,0 +1,76 @@
+package events
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/spf13/cobra"
+)
+
+var GetEvent = &cobra.Command{
+	Use:   "get",
+	Short: "Get events",
+
+	Run: func(cmd *cobra.Command, args []string) {
+
+		// If these where global, unexpected behavior would be expected :(
+		id, _ := cmd.Flags().GetString("id")
+		host, _ := cmd.Flags().GetString("host")
+		port, _ := cmd.Flags().GetString("port")
+
+		getEvents(id, port, host)
+	},
+}
+
+func init() {
+	GetEvent.Flags().String("id", "", "Get a specific event")
+	GetEvent.Flags().String("host", "127.0.0.1", "Custom host (ex: 127.0.0.1)")
+	GetEvent.Flags().String("port", "8080", "Custom port (ex: 8080)")
+}
+
+func getEvents(id string, port string, host string) {
+	if id != "" {
+		fmt.Println("ID entered:", id)
+	}
+
+	// ----- Constructing url -----
+	// Combining Host and port
+	host = string(append([]byte(host), ':'))
+	host = string(append([]byte(host), []byte(port)...))
+
+	// Constructing Path
+	path := "events"
+	if id != "" {
+		path = string(append([]byte(path), '/'))
+		path = string(append([]byte(path), []byte(id)...))
+	}
+
+	getURL := &url.URL{
+		Scheme: "http",
+		Host:   host,
+		Path:   path,
+	}
+
+	//fmt.Println(getURL)
+
+	// ----- Get -----
+	response, err := http.Get(getURL.String())
+	if err != nil {
+		fmt.Println("Error getting the request:", err)
+		return
+	}
+	defer response.Body.Close()
+
+	fmt.Println("Response status:", response.Status)
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		fmt.Println("Failed to read response body:", err)
+		return
+	}
+
+	fmt.Println("Response body:", string(body))
+
+}

--- a/internal/cli/events/get.go
+++ b/internal/cli/events/get.go
@@ -31,20 +31,15 @@ func init() {
 }
 
 func getEvents(id string, port string, host string) {
-	if id != "" {
-		fmt.Println("ID entered:", id)
-	}
 
 	// ----- Constructing url -----
 	// Combining Host and port
-	host = string(append([]byte(host), ':'))
-	host = string(append([]byte(host), []byte(port)...))
+	host = fmt.Sprint(host, ":", port)
 
 	// Constructing Path
 	path := "events"
 	if id != "" {
-		path = string(append([]byte(path), '/'))
-		path = string(append([]byte(path), []byte(id)...))
+		path = fmt.Sprint(path, "/", id)
 	}
 
 	getURL := &url.URL{
@@ -52,8 +47,6 @@ func getEvents(id string, port string, host string) {
 		Host:   host,
 		Path:   path,
 	}
-
-	//fmt.Println(getURL)
 
 	// ----- Get -----
 	response, err := http.Get(getURL.String())
@@ -63,6 +56,7 @@ func getEvents(id string, port string, host string) {
 	}
 	defer response.Body.Close()
 
+	// ----- Read Response Information -----
 	fmt.Println("Response status:", response.Status)
 
 	body, err := io.ReadAll(response.Body)

--- a/internal/cli/events/get.go
+++ b/internal/cli/events/get.go
@@ -57,6 +57,12 @@ func getEvents(id string, port string, host string) {
 		fmt.Println("Error getting the request:", err)
 		return
 	}
+
+	if response == nil {
+		fmt.Println("no response recieved")
+		return
+	}
+
 	defer response.Body.Close()
 
 	// ----- Read Response Information -----

--- a/internal/cli/events/get.go
+++ b/internal/cli/events/get.go
@@ -25,9 +25,12 @@ var GetEvent = &cobra.Command{
 }
 
 func init() {
+
+	// Url Flags
 	GetEvent.Flags().String("id", "", "Get a specific event")
 	GetEvent.Flags().String("host", "127.0.0.1", "Custom host (ex: 127.0.0.1)")
 	GetEvent.Flags().String("port", "8080", "Custom port (ex: 8080)")
+
 }
 
 func getEvents(id string, port string, host string) {

--- a/internal/cli/events/post.go
+++ b/internal/cli/events/post.go
@@ -192,6 +192,12 @@ func postEvent(urlhost string, port string, payload *CreateEvent) {
 		fmt.Println("Failed to post event:", err)
 		return
 	}
+
+	if response == nil {
+		fmt.Println("no response recieved")
+		return
+	}
+
 	defer response.Body.Close()
 
 	// ----- Read Response Info -----

--- a/internal/cli/events/post.go
+++ b/internal/cli/events/post.go
@@ -1,0 +1,155 @@
+package events
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var PostEvent = &cobra.Command{
+	Use:   "post",
+	Short: "Post a new event.",
+
+	Run: promptEvent,
+}
+
+func promptEvent(cmd *cobra.Command, args []string) {
+	newEvent := Event{}
+
+	scanner := bufio.NewScanner(os.Stdin)
+
+	// ----- Uuid -----
+	fmt.Println("Please enter event's uuid:")
+	scanner.Scan()
+	if err := scanner.Err(); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	uuidBuffer := scanner.Bytes()
+	newEvent.Uuid = string(uuidBuffer)
+
+	// ----- Location -----
+	fmt.Println("please enter the event's location:")
+	scanner.Scan()
+	if err := scanner.Err(); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	locationBuffer := scanner.Bytes()
+	newEvent.Location = string(locationBuffer)
+
+	// ----- Start Time -----
+	fmt.Println("Please enter the start time of the event in the following format:\n [Month]/[Day] [Hour]:[Minute]:[Second][PM | AM] '[Last 2 digits of year] -0700")
+	fmt.Println("For example: \x1b[93m01/02 03:04:05PM '06 -0700\x1b[0m")
+	startTime, err := inputTime(scanner)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	newEvent.StartAt = startTime
+
+	// ----- End Time -----
+	fmt.Println("Please enter the end time of the event in the same format as above:")
+	endTime, err := inputTime(scanner)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	newEvent.EndAt = endTime
+
+	// ----- Is all day -----
+	fmt.Println("Is the event all day?")
+	scanner.Scan()
+	if err = scanner.Err(); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	isAllDayBuffer := scanner.Bytes()
+	isAllDayString := strings.ToUpper(string(isAllDayBuffer))
+
+	if isAllDayString == "YES" || isAllDayString == "Y" {
+		newEvent.IsAllDay = true
+	} else if isAllDayString == "NO" || isAllDayString == "N" {
+		newEvent.IsAllDay = false
+	} else {
+		fmt.Println("Invalid input.")
+		return
+	}
+
+	// ----- Host -----
+	fmt.Println("Please enter the event host:")
+	scanner.Scan()
+	if err = scanner.Err(); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	hostBuffer := scanner.Bytes()
+	newEvent.Host = string(hostBuffer)
+
+	// ----- Confirmation -----
+	fmt.Println("Is your event data correct? If not, type n or no. [Note that time is displayed in UNIX time.]\n", newEvent)
+	scanner.Scan()
+	if err = scanner.Err(); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	confirmationBuffer := scanner.Bytes()
+	confirmationString := strings.ToUpper(string(confirmationBuffer))
+
+	if confirmationString == "NO" || confirmationString == "N" {
+		return
+	}
+
+	// ----- Convert to Json -----
+	jsonEvent, err := json.Marshal(newEvent)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// ----- Post -----
+	resp, err := http.Post("http://127.0.0.1:8080/events", "application/json", strings.NewReader(string(jsonEvent)))
+	if err != nil {
+		fmt.Println("Failed to post event:", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	fmt.Println("Response Status:", resp.Status)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println("Failed to read response body:", err)
+		return
+	}
+
+	fmt.Println("Response body:", string(body))
+
+}
+
+func inputTime(scanner *bufio.Scanner) (int64, error) {
+	scanner.Scan()
+	timeBuffer := scanner.Bytes()
+	timeString := string(timeBuffer)
+
+	startTime, err := time.Parse(time.Layout, timeString)
+	if err != nil {
+		return -1, err
+	}
+
+	return startTime.Unix(), nil
+}

--- a/internal/cli/events/put.go
+++ b/internal/cli/events/put.go
@@ -83,6 +83,12 @@ func updateEvent(id string, host string, port string, payload *CreateEvent) {
 		fmt.Printf("Error retrieveing %s: %s", id, err)
 		return
 	}
+
+	if getResponse == nil {
+		fmt.Println("no response recieved")
+		return
+	}
+
 	defer getResponse.Body.Close()
 
 	body, err := io.ReadAll(getResponse.Body)
@@ -234,6 +240,11 @@ func updateEvent(id string, host string, port string, payload *CreateEvent) {
 	putResponse, err := client.Do(request)
 	if err != nil {
 		fmt.Println("Error with response:", err)
+		return
+	}
+
+	if putResponse == nil {
+		fmt.Println("no response recieved")
 		return
 	}
 	defer putResponse.Body.Close()

--- a/internal/cli/events/put.go
+++ b/internal/cli/events/put.go
@@ -1,0 +1,319 @@
+package events
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/acmcsufoss/api.acmcsuf.com/utils/convert"
+	_ "github.com/acmcsufoss/api.acmcsuf.com/utils/dbtypes"
+	"github.com/spf13/cobra"
+)
+
+var PutEvents = &cobra.Command{
+	Use:   "put",
+	Short: "Used to update an event",
+
+	Run: func(cmd *cobra.Command, args []string) {
+
+		id, err := cmd.Flags().GetString("id")
+		if err != nil {
+			fmt.Println("Event ID is required!")
+			return
+		}
+
+		payload := Event{}
+
+		// CLI for url
+		host, _ := cmd.Flags().GetString("urlhost")
+		port, _ := cmd.Flags().GetString("port")
+
+		// CLI for payload
+		payload.Uuid, _ = cmd.Flags().GetString("uuid")
+		payload.Location, _ = cmd.Flags().GetString("location")
+		payload.StartAt, _ = cmd.Flags().GetInt64("startat")
+		payload.EndAt, _ = cmd.Flags().GetInt64("endat")
+		payload.IsAllDay, _ = cmd.Flags().GetBool("allday")
+		payload.Host, _ = cmd.Flags().GetString("host")
+		updateEvent(id, host, port, &payload)
+	},
+}
+
+func init() {
+	// URL Flags
+	PutEvents.Flags().String("id", "", "Event to update")
+	PutEvents.Flags().String("urlhost", "127.0.0.1", "Custom host (ex: 127.0.0.1)")
+	PutEvents.Flags().String("port", "8080", "Custom port (ex: 8080)")
+
+	// Payload flags
+	PutEvents.Flags().String("uuid", "", "Change uuid of event")
+	PutEvents.Flags().String("location", "", "Change location of event")
+	PutEvents.Flags().Int("startat", 0, "Change the start time of event")
+	PutEvents.Flags().Int("endat", 0, "Change the end time of event")
+	PutEvents.Flags().String("host", "", "Change host of event")
+	PutEvents.Flags().Bool("allday", false, "Change if event is all day")
+}
+
+func updateEvent(id string, host string, port string, payload *Event) {
+	if id == "" {
+		fmt.Println("Event ID is required!")
+		return
+	}
+
+	// ----- Constructing Url -----
+	host = fmt.Sprint(host, ":", port)
+
+	path := fmt.Sprint("events", "/", id)
+
+	retrievalURL := &url.URL{
+		Scheme: "http",
+		Host:   host,
+		Path:   path,
+	}
+
+	// ----- Retrieve payload -----
+	getResponse, err := http.Get(retrievalURL.String())
+	if err != nil {
+		fmt.Printf("Error retrieveing %s: %s", id, err)
+		return
+	}
+	defer getResponse.Body.Close()
+
+	body, err := io.ReadAll(getResponse.Body)
+	if err != nil {
+		fmt.Println("Error reading response body:", err)
+		return
+	}
+
+	var oldpayload Event
+	json.Unmarshal(body, &oldpayload)
+
+	scanner := bufio.NewScanner(os.Stdin)
+
+	// ----- Change the event -----
+	// Note: We want to PUT the payload, not old payload
+	// payload values are empty if user did not input a value in the command line
+
+	// ----- uuid -----
+	if payload.Uuid == "" {
+		changeTheEventUuid, err := changePrompt("uuid", oldpayload.Uuid, scanner)
+		if err != nil {
+			fmt.Println(err) // Custom errors in changePrompt()
+			return
+		}
+
+		if changeTheEventUuid {
+			newUuidBuffer := scanner.Bytes()
+			payload.Uuid = string(newUuidBuffer)
+		} else {
+			payload.Uuid = oldpayload.Uuid
+		}
+
+	}
+
+	// ----- Location -----
+	if payload.Location == "" {
+		changeTheEventLocation, err := changePrompt("location", oldpayload.Location, scanner)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		if changeTheEventLocation {
+			newLocationBuffer := scanner.Bytes()
+			payload.Location = string(newLocationBuffer)
+		} else {
+			payload.Location = oldpayload.Location
+		}
+	}
+
+	// ----- Start time -----
+	if payload.StartAt == 0 {
+		changeTheEventStartAt, err := changePrompt("start time", strconv.FormatInt(oldpayload.StartAt, 10), scanner)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		if changeTheEventStartAt {
+			newStartAtBuffer := scanner.Bytes()
+			payload.StartAt, err = convert.ByteSlicetoInt64(newStartAtBuffer)
+			if err != nil {
+				fmt.Println("Error with reading start integer:", err)
+				return
+			}
+		} else {
+			payload.StartAt = oldpayload.StartAt
+		}
+	}
+
+	// ----- End time -----
+	if payload.EndAt == 0 {
+		changeTheEventEndAt, err := changePrompt("end time", strconv.FormatInt(oldpayload.EndAt, 10), scanner)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		if changeTheEventEndAt {
+			newEndAtBuffer := scanner.Bytes()
+			payload.EndAt, err = convert.ByteSlicetoInt64(newEndAtBuffer)
+			if err != nil {
+				fmt.Println("Error with reading end integer:", err)
+				return
+			}
+		} else {
+			payload.EndAt = oldpayload.EndAt
+		}
+	}
+
+	// ----- All day -----
+	// This is kind of awkward but I don't know have a workaround at the moment
+	if !payload.IsAllDay {
+		changeTheEventAllDay, err := changePrompt("all day status", strconv.FormatBool(oldpayload.IsAllDay), scanner)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		if changeTheEventAllDay {
+			newAllDayBuffer := scanner.Bytes()
+			payload.IsAllDay, err = yesOrNo(newAllDayBuffer, scanner)
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+		} else {
+			payload.IsAllDay = oldpayload.IsAllDay
+		}
+	}
+
+	// ----- Host -----
+	if payload.Host == "" {
+		changeTheEventHost, err := changePrompt("host", oldpayload.Host, scanner)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		if changeTheEventHost {
+			newHostBuffer := scanner.Bytes()
+			payload.Host = string(newHostBuffer)
+		} else {
+			payload.Host = oldpayload.Host
+		}
+	}
+
+	// ----- PUT the payload -----
+
+	/*updatePayload := PutEvent{
+		Uuid:     payload.Uuid,
+		Location: toNullString(payload.Location),
+		StartAt:  toNullInt64(payload.StartAt),
+		EndAt:    toNullInt64(payload.EndAt),
+		IsAllDay: sql.NullBool{
+			Bool:  payload.IsAllDay,
+			Valid: true,
+		},
+		Host: toNullString(payload.Host),
+	}*/
+	updatePayload := PutEvent{
+		Uuid:     &payload.Uuid,
+		Location: &payload.Location,
+		StartAt:  &payload.StartAt,
+		EndAt:    &payload.EndAt,
+		IsAllDay: &payload.IsAllDay,
+		Host:     &payload.Host,
+	}
+
+	newPayload, err := json.Marshal(updatePayload)
+	if err != nil {
+		fmt.Println("Error marshaling data:", err)
+		return
+	}
+
+	client := &http.Client{}
+
+	request, err := http.NewRequest(http.MethodPut, retrievalURL.String(), bytes.NewBuffer(newPayload))
+	if err != nil {
+		fmt.Println("Problem with PUT:", err)
+		return
+	}
+
+	putResponse, err := client.Do(request)
+	if err != nil {
+		fmt.Println("Error with response:", err)
+		return
+	}
+	defer putResponse.Body.Close()
+
+	body, err = io.ReadAll(putResponse.Body)
+	if err != nil {
+		fmt.Println("Error with body:", err)
+		return
+	}
+
+	fmt.Println(string(body))
+}
+
+// ============================================= Helper functions =============================================
+
+// The following function does these things:
+// 1. Ask the user if they want to chnage [x] data
+// 2. User inputs a response to scanner
+// 3. If yesOrNo() is true then:
+// 4. Prompt user for new data [x]
+// 5. Scanner scans the users response
+// 6. Return true. Scanner holds the byte slice which can be used by the function that called this one
+// Note: I think this is a little risky, I believe it would be very easy to override the bytes slice by accident.
+//
+//	If the person reading this thinks there is a better way to manage scanner, then by all means go ahead and try.
+
+// Returns a bool, indicating if the user wants to change the current data field passed into the function
+func changePrompt(dataToBeChanged string, currentData string, scanner *bufio.Scanner) (bool, error) {
+	fmt.Printf("Would you like to change this event's \x1b[1m%s\x1b[0m?[y/n]\nCurrent event's %s: \x1b[93m%s\x1b[0m\n", dataToBeChanged, dataToBeChanged, currentData)
+	scanner.Scan()
+	if err := scanner.Err(); err != nil {
+		return false, fmt.Errorf("error reading input: %s", err)
+	}
+	userInput := scanner.Bytes()
+
+	changeData, err := yesOrNo(userInput, scanner)
+	if err != nil {
+		return false, err
+	}
+	if changeData {
+		fmt.Printf("Please enter a new \x1b[1m%s\x1b[0m for the event:\n", dataToBeChanged)
+		scanner.Scan()
+		if err := scanner.Err(); err != nil {
+			return false, fmt.Errorf("error reading new %s: %s", dataToBeChanged, err)
+		}
+		return true, nil
+	} else {
+		return false, nil
+	}
+}
+
+func yesOrNo(userInput []byte, scanner *bufio.Scanner) (bool, error) {
+	userInputString := strings.ToUpper(string(userInput))
+
+	if userInputString == "YES" || userInputString == "Y" || userInputString == "TRUE" {
+		return true, nil
+	} else if userInputString == "NO" || userInputString == "N" || userInputString == "FALSE" {
+		return false, nil
+	} else {
+		fmt.Println("Invalid input, please try again.")
+		scanner.Scan()
+		if err := scanner.Err(); err != nil {
+			return false, fmt.Errorf("error scanning new input: %s", err)
+		}
+		return yesOrNo(scanner.Bytes(), scanner)
+	}
+}

--- a/utils/convert/convert.go
+++ b/utils/convert/convert.go
@@ -1,0 +1,34 @@
+package convert
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+func ByteSlicetoInt64(data []byte) (int64, error) {
+	// Padding, if number is too short we run into the eof and get an error (see binary.Read)
+	/*if len(data) < 8 {
+		padded := make([]byte, 8-len(data), 8)
+		data = append(padded, data...)
+	}
+	*/
+	fmt.Printf("%d, %v", data, data)
+	number, err := strconv.Atoi(string(data))
+	if err != nil {
+		return 0, fmt.Errorf("error converting bytes to int: %s", err)
+	}
+
+	return int64(number), nil
+}
+
+func ByteSlicetoUnix(data []byte) (int64, error) {
+	timeString := string(data)
+
+	startTime, err := time.Parse(time.Layout, timeString)
+	if err != nil {
+		return -1, err
+	}
+
+	return startTime.Unix(), nil
+}

--- a/utils/convert/convert.go
+++ b/utils/convert/convert.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+// A lot of
+
 func ByteSlicetoInt64(data []byte) (int64, error) {
 	// Padding, if number is too short we run into the eof and get an error (see binary.Read)
 	/*if len(data) < 8 {

--- a/utils/dbtypes/dbtypes.go
+++ b/utils/dbtypes/dbtypes.go
@@ -2,6 +2,8 @@ package dbtypes
 
 import "database/sql"
 
+// Utilities for Go types to Sql null types
+
 func StringtoNullString(str string) sql.NullString {
 	return sql.NullString{
 		String: str,

--- a/utils/dbtypes/dbtypes.go
+++ b/utils/dbtypes/dbtypes.go
@@ -1,0 +1,24 @@
+package dbtypes
+
+import "database/sql"
+
+func StringtoNullString(str string) sql.NullString {
+	return sql.NullString{
+		String: str,
+		Valid:  str != "",
+	}
+}
+
+func Int64toNullInt64(i int64) sql.NullInt64 {
+	return sql.NullInt64{
+		Int64: i,
+		Valid: i != 0,
+	}
+}
+
+func BooltoNullBool(b bool) sql.NullBool {
+	return sql.NullBool{
+		Bool:  b,
+		Valid: true,
+	}
+}


### PR DESCRIPTION
Adds CLI Tools for managing http headers of Events and Announcements

# To use:
1. cd into cmd/csuf
2. go install .
3. export PATH="$HOME/go/bin:$PATH"
4. Type csuf -h for help

### Example usage:
csuf events post
csuf announcements get --id announcement1 (--id=<uuid> also works)

## Known issues:
Announcement POST and Events PUT run into a 500 error
Announcement PUT can not update the uuid

### Other comments:
Planning on writing a more elaborate description for each CLI command for help command (and maybe manual)