### PR TITLE
Update environment variable loading to be more friendly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL="file:dev.db?cache=shared&mode=rwc"

--- a/.envrc
+++ b/.envrc
@@ -3,5 +3,6 @@ if ! has nix_direnv_version || ! nix_direnv_version 3.1.0; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.0/direnvrc" "sha256-yMJ2OVMzrFaDPn7q8nCBZFRYpL/f0RcHzhmw/i6btJM="
 fi
 use flake
+layout go
 PATH_add bin
 dotenv ./.env

--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,8 @@
 # shellcheck shell=bash
-if ! has nix_direnv_version || ! nix_direnv_version 3.1.0; then
-  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.0/direnvrc" "sha256-yMJ2OVMzrFaDPn7q8nCBZFRYpL/f0RcHzhmw/i6btJM="
+if has nix; then
+  if ! has nix_direnv_version || ! nix_direnv_version 3.1.0; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.0/direnvrc" "sha256-yMJ2OVMzrFaDPn7q8nCBZFRYpL/f0RcHzhmw/i6btJM="
+  fi
 fi
 use flake
 layout go

--- a/.envrc
+++ b/.envrc
@@ -1,13 +1,5 @@
-if ! has nix; then
-  echo -e "\033[31mWARNING: Nix is not installed!\033[0m"
-  echo -e "\033[31mWe recommend using Determinate Nix Installer to get started: https://determinate.systems/nix-installer/\033[0m"
-  exit 1
+# shellcheck shell=bash
+if ! has nix_direnv_version || ! nix_direnv_version 3.1.0; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.0/direnvrc" "sha256-yMJ2OVMzrFaDPn7q8nCBZFRYpL/f0RcHzhmw/i6btJM="
 fi
-
-watch_file nix/shell.nix
 use flake
-
-if ! has nix-direnv-reload; then
-  echo -e "\033[31mWARNING: nix-direnv is recommended for better performance and caching.\033[0m"
-  echo -e "\033[31mTo install, see https://github.com/nix-community/nix-direnv\033[0m"
-fi

--- a/.envrc
+++ b/.envrc
@@ -3,3 +3,5 @@ if ! has nix_direnv_version || ! nix_direnv_version 3.1.0; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.0/direnvrc" "sha256-yMJ2OVMzrFaDPn7q8nCBZFRYpL/f0RcHzhmw/i6btJM="
 fi
 use flake
+PATH_add bin
+dotenv ./.env

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ result
 .generate.marker
 
 tmp/
+
+.env

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -32,9 +32,11 @@ mkShell {
   ];
 
   shellHook = ''
-    export DATABASE_URL="file:dev.db?cache=shared&mode=rwc"
     export CGO_ENABLED=0  # cgo compiler flags cause issues with delve when using Nix
-    export PATH="$PWD/bin:$PATH"
+    if [ ! -f .env ]; then
+      echo ".env file not found! Creating one from .env.example for you..."
+      cp .env.example .env
+    fi
     echo -e "\e[32mLoaded nix dev shell\e[0m"
   '';
 }


### PR DESCRIPTION
sorry for spamming u sid!

---

This accomodates non-nix users by using a more traditional `.env` file for environment variables. If you're already a nix user, the nix dev shell will create the `.env` file from `.env.example` automatically
  
Also removes warnings from .envrc for those using direnv