### PR TITLE
fix: rm problematic `layout go` line in .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,6 +5,5 @@ if has nix; then
   fi
 fi
 use flake
-layout go
 PATH_add bin
 dotenv ./.env


### PR DESCRIPTION
Created issue for direnv users that introduced a different version of Go