### PR TITLE
Remove go migrate from flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769598131,
-        "narHash": "sha256-e7VO/kGLgRMbWtpBqdWl0uFg8Y2XWFMdz0uUJvlML8o=",
+        "lastModified": 1775305101,
+        "narHash": "sha256-/74n1oQPtKG52Yw41cbToxspxHbYz6O3vi+XEw16Qe8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa83fd837f3098e3e678e6cf017b2b36102c7211",
+        "rev": "36a601196c4ebf49e035270e10b2d103fe39076b",
         "type": "github"
       },
       "original": {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -12,15 +12,11 @@
   go-swag,
   cobra-cli,
   go-tools,
-  go-migrate,
   sqlite,
   sqlite-web,
   isCI ? false,
   full ? false,
 }: let
-  go-migrate-sqlite = go-migrate.overrideAttrs (oldAttrs: {
-    tags = ["sqlite3"];
-  });
 in
   mkShell {
     packages =
@@ -37,7 +33,6 @@ in
       ++ lib.optionals (!isCI) [
         air # run dev server with hot reload
         xh
-        go-migrate-sqlite
         sqlite
         cobra-cli
         delve # Go debugger


### PR DESCRIPTION
This PR removes the `go migrate` cli tool from the nix flake. Since migration is now being done programmatically (#170) we no longer need the `go migrate` cli tool.