### PR TITLE
chore: remove migration commands and instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,6 @@ CLI_NAME := acmcsuf-cli
 GO_SOURCES := $(shell find . -type f -name '*.go' -not -path '*/vendor/*')
 GO_DEPS := $(GO_SOURCES) go.mod go.sum
 
-MIGRATE_DIR := sql/migrations
-DB_URL := sqlite3://dev.db
-
 SQLC_DEPS := $(wildcard sql/migrations/*.sql) $(wildcard sql/queries/*.sql)
 SQLC_TARGET := internal/api/dbmodels/models.go
 
@@ -69,13 +66,7 @@ clean: ## Clean up binaries and build artifacts
 	go clean
 	rm -rf $(BIN_DIR) result
 
-migrate-up: ## Perform database migration up
-	migrate -database $(DB_URL) -path $(MIGRATE_DIR) up
-
-migrate-down: ## Perform database migration down
-	migrate -database $(DB_URL) -path $(MIGRATE_DIR) down 1
-
 help: ## Display this help screen
 	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: help fmt run build all api cli check test check-sql fix-sql clean release generate migrate-up migrate-down
+.PHONY: help fmt run build all api cli check test check-sql fix-sql clean release generate

--- a/README.md
+++ b/README.md
@@ -31,12 +31,6 @@ air
 make run
 ```
 
-### Running database migrations
-After starting the server, you need to apply the database migrations in order to create the database schema.
-```sh
-make migrate-up
-```
-
 #### Configuring the API
 The API server is configurable via environment variables. See [`.env.example`](./.env.example) for values you can override and configure in your `.env` file.
 


### PR DESCRIPTION
The migration command is already ran programmatically when spinning up the API. Removing the `make migrate-*` commands from and `Running database migrations` section from README since users are no longer required to perform this step.