### PR TITLE
Proposal: Custom Linter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,10 @@ jobs:
         if: steps.filter.outputs.source_code == 'true'
         run: nix develop .#ci -c bash -c "make fmt && git diff --exit-code"
 
+      - name: Linter check
+        if: steps.filter.outputs.source_code == 'true'
+        run: nix develop .#ci -c make linter
+
       - name: Check
         if: steps.filter.outputs.source_code == 'true'
         run: nix develop .#ci -c make check

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ check-sql: ## Lint all sql files
 fix-sql: ## Fix all sql files
 	sqlfluff fix --dialect sqlite
 
+linter:
+	go run cmd/linter/main.go
+
 release: ## Create a new release tag
 	@echo "Current version: $(VERSION)"
 	@read -p "Enter new version (e.g., v0.2.0): " version; \
@@ -69,4 +72,4 @@ clean: ## Clean up binaries and build artifacts
 help: ## Display this help screen
 	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: help fmt run build all api cli check test check-sql fix-sql clean release generate
+.PHONY: help fmt run build all api cli check test check-sql fix-sql clean release generate linter

--- a/cmd/linter/main.go
+++ b/cmd/linter/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+)
+
+var filesToSkip []string = []string{".", "swagger.go"}
+
+func main() {
+
+	// Go to api/handlers
+	// This should be run in the project root
+	handlersPath := "internal/api/handlers/"
+	os.Chdir(handlersPath)
+
+	err := filepath.Walk(".", func(path string, info fs.FileInfo, err error) error {
+		if slices.Contains(filesToSkip, path) {
+			return nil
+		}
+
+		// Creating an AST tree by parsing
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			log.Println(err)
+			os.Exit(1)
+		}
+
+		// Now we can search for specific things like functions and imports
+		ast.Inspect(file, func(n ast.Node) bool {
+			// looking for an import, we shouldn't have dbmodels in handler
+			switch x := n.(type) {
+			case *ast.ImportSpec:
+
+				importedModule, _ := strconv.Unquote(x.Path.Value)
+
+				// yah messy, but for the sake of proposal
+				check := (importedModule == "github.com/acmcsufoss/api.acmcsuf.com/internal/api/store/dbmodels")
+				if check {
+					// This error is going to make me throw up lol
+					log.Println(errors.New("Bad import found: " + importedModule + " in " + handlersPath + path))
+					os.Exit(1)
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
+}

--- a/cmd/linter/main.go
+++ b/cmd/linter/main.go
@@ -1,62 +1,17 @@
 package main
 
 import (
-	"errors"
-	"go/ast"
-	"go/parser"
-	"go/token"
-	"io/fs"
-	"log"
 	"os"
-	"path/filepath"
-	"slices"
-	"strconv"
+
+	"github.com/acmcsufoss/api.acmcsuf.com/internal/linter"
 )
 
-var filesToSkip []string = []string{".", "swagger.go"}
-
 func main() {
+	rules := linter.LinterRules()
 
-	// Go to api/handlers
-	// This should be run in the project root
-	handlersPath := "internal/api/handlers/"
-	os.Chdir(handlersPath)
-
-	err := filepath.Walk(".", func(path string, info fs.FileInfo, err error) error {
-		if slices.Contains(filesToSkip, path) {
-			return nil
-		}
-
-		// Creating an AST tree by parsing
-		fset := token.NewFileSet()
-		file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
-		if err != nil {
-			log.Println(err)
-			os.Exit(1)
-		}
-
-		// Now we can search for specific things like functions and imports
-		ast.Inspect(file, func(n ast.Node) bool {
-			// looking for an import, we shouldn't have dbmodels in handler
-			switch x := n.(type) {
-			case *ast.ImportSpec:
-
-				importedModule, _ := strconv.Unquote(x.Path.Value)
-
-				// yah messy, but for the sake of proposal
-				check := (importedModule == "github.com/acmcsufoss/api.acmcsuf.com/internal/api/store/dbmodels")
-				if check {
-					// This error is going to make me throw up lol
-					log.Println(errors.New("Bad import found: " + importedModule + " in " + handlersPath + path))
-					os.Exit(1)
-				}
-			}
-			return true
-		})
-		return nil
-	})
-	if err != nil {
-		log.Println(err)
-		os.Exit(1)
+	for _, rule := range rules {
+		linter.Lint(rule)
 	}
+
+	os.Exit(0)
 }

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -1,4 +1,4 @@
-package linter 
+package linter
 
 import (
 	"errors"
@@ -14,7 +14,7 @@ import (
 )
 
 func Lint(rule lintRule) {
-	
+
 	os.Chdir(rule.path)
 
 	err := filepath.Walk(".", func(path string, info fs.FileInfo, err error) error {
@@ -39,7 +39,7 @@ func Lint(rule lintRule) {
 
 				importedModule, _ := strconv.Unquote(x.Path.Value)
 
-				if  slices.Contains(rule.badImports, importedModule) {
+				if slices.Contains(rule.badImports, importedModule) {
 					log.Println(errors.New("Bad import found: " + importedModule + " in " + rule.path + path))
 					os.Exit(1)
 				}

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -1,0 +1,55 @@
+package linter 
+
+import (
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+)
+
+func Lint(rule lintRule) {
+	
+	os.Chdir(rule.path)
+
+	err := filepath.Walk(".", func(path string, info fs.FileInfo, err error) error {
+		if slices.Contains(rule.skipFiles, path) {
+			return nil
+		}
+
+		// Creating an AST tree by parsing
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			log.Println(err)
+			os.Exit(1)
+		}
+
+		// Now we can search for specific things like functions and imports
+		ast.Inspect(file, func(n ast.Node) bool {
+			switch x := n.(type) {
+
+			// Import check
+			case *ast.ImportSpec:
+
+				importedModule, _ := strconv.Unquote(x.Path.Value)
+
+				if  slices.Contains(rule.badImports, importedModule) {
+					log.Println(errors.New("Bad import found: " + importedModule + " in " + rule.path + path))
+					os.Exit(1)
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
+}

--- a/internal/linter/linterRules.go
+++ b/internal/linter/linterRules.go
@@ -1,0 +1,61 @@
+package linter
+
+//
+// Rules for linting
+// Right now just deals with bad imports but can be added onto later
+//
+type lintRule struct {
+
+	// Path to check
+	path string
+
+	// Files to skip in a path
+	skipFiles []string
+
+	// Imports that should not be in a file
+	badImports []string
+
+}
+
+func LinterRules() []lintRule {
+	var rules []lintRule
+
+	// ====================== API RULES ====================== 
+	handlerRule := lintRule{
+		path: "internal/api/handlers/",
+		skipFiles: []string{".", "swagger.go"},
+		badImports: []string{"github.com/acmcsufoss/api.acmcsuf.com/internal/api/store/dbmodels"}, 
+	}
+	rules = append(rules, handlerRule)
+
+	// CLI and API linter rules could probably be split in the future for faster test times
+
+	// ====================== CLI RULES ====================== 
+	cliPath := "internal/cli" 
+	announcementsCLIRule := lintRule{
+		path: cliPath + "/announcements/",
+		skipFiles: []string{".", "root.go"},
+		badImports: []string{"github.com/acmcsufoss/api.acmcsuf.com/internal/api/store/dbmodels"}, 
+	}
+
+	rules = append(rules, announcementsCLIRule)
+	
+	eventsCLIRule := lintRule{
+		path: cliPath + "/events/",
+		skipFiles: []string{".", "root.go"},
+		badImports: []string{"github.com/acmcsufoss/api.acmcsuf.com/internal/api/store/dbmodels"}, 
+	}
+
+	rules = append(rules, eventsCLIRule)
+
+	officersCLIRule := lintRule{
+		path: cliPath + "/officers/",
+		skipFiles: []string{".", "root.go"},
+		badImports: []string{"github.com/acmcsufoss/api.acmcsuf.com/internal/api/store/dbmodels"}, 
+	}
+
+	rules = append(rules, officersCLIRule)
+
+	return rules
+}
+

--- a/internal/linter/linterRules.go
+++ b/internal/linter/linterRules.go
@@ -1,9 +1,7 @@
 package linter
 
-//
 // Rules for linting
 // Right now just deals with bad imports but can be added onto later
-//
 type lintRule struct {
 
 	// Path to check
@@ -14,48 +12,46 @@ type lintRule struct {
 
 	// Imports that should not be in a file
 	badImports []string
-
 }
 
 func LinterRules() []lintRule {
 	var rules []lintRule
 
-	// ====================== API RULES ====================== 
+	// ====================== API RULES ======================
 	handlerRule := lintRule{
-		path: "internal/api/handlers/",
-		skipFiles: []string{".", "swagger.go"},
-		badImports: []string{"github.com/acmcsufoss/api.acmcsuf.com/internal/api/store/dbmodels"}, 
+		path:       "internal/api/handlers/",
+		skipFiles:  []string{".", "swagger.go"},
+		badImports: []string{"github.com/acmcsufoss/api.acmcsuf.com/internal/api/store/dbmodels"},
 	}
 	rules = append(rules, handlerRule)
 
 	// CLI and API linter rules could probably be split in the future for faster test times
 
-	// ====================== CLI RULES ====================== 
-	cliPath := "internal/cli" 
+	// ====================== CLI RULES ======================
+	cliPath := "internal/cli"
 	announcementsCLIRule := lintRule{
-		path: cliPath + "/announcements/",
-		skipFiles: []string{".", "root.go"},
-		badImports: []string{"github.com/acmcsufoss/api.acmcsuf.com/internal/api/store/dbmodels"}, 
+		path:       cliPath + "/announcements/",
+		skipFiles:  []string{".", "root.go"},
+		badImports: []string{"github.com/acmcsufoss/api.acmcsuf.com/internal/api/store/dbmodels"},
 	}
 
 	rules = append(rules, announcementsCLIRule)
-	
+
 	eventsCLIRule := lintRule{
-		path: cliPath + "/events/",
-		skipFiles: []string{".", "root.go"},
-		badImports: []string{"github.com/acmcsufoss/api.acmcsuf.com/internal/api/store/dbmodels"}, 
+		path:       cliPath + "/events/",
+		skipFiles:  []string{".", "root.go"},
+		badImports: []string{"github.com/acmcsufoss/api.acmcsuf.com/internal/api/store/dbmodels"},
 	}
 
 	rules = append(rules, eventsCLIRule)
 
 	officersCLIRule := lintRule{
-		path: cliPath + "/officers/",
-		skipFiles: []string{".", "root.go"},
-		badImports: []string{"github.com/acmcsufoss/api.acmcsuf.com/internal/api/store/dbmodels"}, 
+		path:       cliPath + "/officers/",
+		skipFiles:  []string{".", "root.go"},
+		badImports: []string{"github.com/acmcsufoss/api.acmcsuf.com/internal/api/store/dbmodels"},
 	}
 
 	rules = append(rules, officersCLIRule)
 
 	return rules
 }
-


### PR DESCRIPTION
Hello, I was messing around with go/ast and had an idea we could make a custom linter for our project.

# Why?

A custom linter can be useful for our projects to enforce architectural rules, for example here in this proposal I am enforcing the rule of no dbmodel imports in the api handlers. I think this will help future contributors follow architectural rules that they may not be aware off by getting caught in the ci first and reading about it possibly. The ci will fail if merged, which means it is currently working as intended.

It's pretty messy right now in the proposal state, but I want to put the idea out there for you all. Feel free to leave thoughts/comments/questions about it, Ill answer them.

