### PR TITLE
Add caching for Nix in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,10 +29,6 @@ jobs:
         if: steps.filter.outputs.source_code == 'true'
         uses: DeterminateSystems/nix-installer-action@main
         
-      - name: Cache Nix
-        if: steps.filter.outputs.source_code == 'true'
-        uses: DeterminateSystems/magic-nix-cache-action@main
-
       - name: CI
         run: |
           nix develop .#ci --command bash -c '

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,26 +33,13 @@ jobs:
         if: steps.filter.outputs.source_code == 'true'
         uses: DeterminateSystems/magic-nix-cache-action@main
 
-      - name: Format check
-        if: steps.filter.outputs.source_code == 'true'
-        run: nix develop .#ci -c bash -c "make fmt && git diff --exit-code"
-
-      - name: Check
-        if: steps.filter.outputs.source_code == 'true'
-        run: nix develop .#ci -c make check
-
-      - name: Sql check
-        if: steps.filter.outputs.source_code == 'true'
-        run: nix develop .#ci -c make check-sql
-
-      - name: Build
-        if: steps.filter.outputs.source_code == 'true'
-        run: nix develop .#ci -c make build
-
-      - name: Generated files check
-        if: steps.filter.outputs.source_code == 'true'
-        run: nix develop .#ci -c bash -c "make generate && git diff --exit-code"
-
-      - name: Test
-        if: steps.filter.outputs.source_code == 'true'
-        run: nix develop .#ci -c make test
+      - name: CI
+        run: |
+          nix develop .#ci --command bash -c '
+            make fmt && git diff --exit-code
+            make check
+            make check-sql
+            make build
+            make generate && git diff --exit-code
+            make test
+          '

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,10 @@ jobs:
       - name: Install Nix
         if: steps.filter.outputs.source_code == 'true'
         uses: DeterminateSystems/nix-installer-action@main
+        
+      - name: Cache Nix
+        if: steps.filter.outputs.source_code == 'true'
+        uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Format check
         if: steps.filter.outputs.source_code == 'true'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .DEFAULT_GOAL := build
 
+#test
+
 BIN_DIR := bin
 API_NAME := acmcsuf-api
 CLI_NAME := acmcsuf-cli

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 .DEFAULT_GOAL := build
 
-#test
 
 BIN_DIR := bin
 API_NAME := acmcsuf-api


### PR DESCRIPTION
The current CI spends a lot of time setting up nix. This PR introduces cacheing for nix so that our CI time will go down dramatically.